### PR TITLE
Move the cell to be re-ordered instead of the reverse

### DIFF
--- a/HPReorderTableView/HPReorderTableView.m
+++ b/HPReorderTableView/HPReorderTableView.m
@@ -123,6 +123,7 @@ static NSString *HPReorderTableViewCellReuseIdentifier = @"HPReorderTableViewCel
     {
         UITableViewCell *cell = [self dequeueReusableCellWithIdentifier:HPReorderTableViewCellReuseIdentifier];
         cell.accessoryType = UITableViewCellAccessoryNone;
+		cell.layer.zPosition = -10;
         return cell;
     }
     else
@@ -296,7 +297,7 @@ static void HPGestureRecognizerCancel(UIGestureRecognizer *gestureRecognizer)
 - (void)reorderCurrentRowToIndexPath:(NSIndexPath*)toIndexPath
 {
     [self beginUpdates];
-    [self moveRowAtIndexPath:toIndexPath toIndexPath:_reorderCurrentIndexPath]; // Order is important to keep the empty cell behind
+    [self moveRowAtIndexPath:_reorderCurrentIndexPath toIndexPath:toIndexPath];
     if ([self.dataSource respondsToSelector:@selector(tableView:moveRowAtIndexPath:toIndexPath:)])
     {
         [self.dataSource tableView:self moveRowAtIndexPath:_reorderCurrentIndexPath toIndexPath:toIndexPath];


### PR DESCRIPTION
Moves the cell being re-ordered instead of the reverse in order to stop the cells being mixed up when dragging too fast. Prevents the placeholder cell being drawn on top of the other cells by lowering its zPosition.

This fixes #11.
