### PR TITLE
lock rows that can not be ordered

### DIFF
--- a/HPReorderTableView/HPReorderTableView.h
+++ b/HPReorderTableView/HPReorderTableView.h
@@ -22,6 +22,8 @@
 @protocol HPReorderTableViewDelegate <UITableViewDelegate>
 @optional
 - (void)tableView:(UITableView *)tableView didEndReorderingRowAtIndexPath:(NSIndexPath *)indexPath;
+- (void)tableView:(UITableView *)tableView willBeginReorderingRowAtIndexPath:(NSIndexPath *)indexPath;
+- (void)tableView:(UITableView *)tableView didBeginReorderingRowAtIndexPath:(NSIndexPath *)indexPath;
 @end
 
 /**

--- a/HPReorderTableView/HPReorderTableView.h
+++ b/HPReorderTableView/HPReorderTableView.h
@@ -21,6 +21,7 @@
 
 @protocol HPReorderTableViewDelegate <UITableViewDelegate>
 @optional
+- (void)tableView:(UITableView *)tableView didCancelReorderingRowAtIndexPath:(NSIndexPath *)indexPath;
 - (void)tableView:(UITableView *)tableView didEndReorderingRowAtIndexPath:(NSIndexPath *)indexPath;
 - (void)tableView:(UITableView *)tableView willBeginReorderingRowAtIndexPath:(NSIndexPath *)indexPath;
 - (void)tableView:(UITableView *)tableView didBeginReorderingRowAtIndexPath:(NSIndexPath *)indexPath;
@@ -48,6 +49,11 @@
  Provide your UITableViewCell subclass to set the appeareance of the temporary empty cell during dragging. An empty UITableViewCell is used by default, which leaves the empty space white.
  */
 - (void)registerTemporaryEmptyCellClass:(Class)cellClass;
+
+/**
+ Allow the caller to end any reorder that is in progress.
+ */
+- (void)endAnyExistingReorder;
 
 @end
 

--- a/HPReorderTableView/HPReorderTableView.h
+++ b/HPReorderTableView/HPReorderTableView.h
@@ -25,6 +25,10 @@
 - (void)tableView:(UITableView *)tableView didEndReorderingRowAtIndexPath:(NSIndexPath *)indexPath;
 - (void)tableView:(UITableView *)tableView willBeginReorderingRowAtIndexPath:(NSIndexPath *)indexPath;
 - (void)tableView:(UITableView *)tableView didBeginReorderingRowAtIndexPath:(NSIndexPath *)indexPath;
+/**
+ *  Can this row be allowed to be dragged. As opposed to canMoveRowAtIndexPath where determines is the row can move at all.
+ */
+- (BOOL)canDragRowAtIndexPath:(NSIndexPath *)indexPath;
 @end
 
 /**

--- a/HPReorderTableView/HPReorderTableView.m
+++ b/HPReorderTableView/HPReorderTableView.m
@@ -198,6 +198,13 @@ static NSString *HPReorderTableViewCellReuseIdentifier = @"HPReorderTableViewCel
     return ![self.dataSource respondsToSelector:@selector(tableView:canMoveRowAtIndexPath:)] || [self.dataSource tableView:self canMoveRowAtIndexPath:indexPath];
 }
 
+- (BOOL)canDragRowAtIndexPath:(NSIndexPath *)indexPath {
+    if ([self.delegate respondsToSelector:@selector(canDragRowAtIndexPath:)]) {
+        return [self.delegate canDragRowAtIndexPath:indexPath];
+    }
+    return YES;
+}
+
 - (BOOL)hasRows
 {
     NSInteger sectionCount = [self numberOfSections];
@@ -240,7 +247,7 @@ static void HPGestureRecognizerCancel(UIGestureRecognizer *gestureRecognizer)
 {
     const CGPoint location = [gestureRecognizer locationInView:self];
     NSIndexPath *indexPath = [self indexPathForRowAtPoint:location];
-    if (indexPath == nil || ![self canMoveRowAtIndexPath:indexPath])
+    if (indexPath == nil || ![self canMoveRowAtIndexPath:indexPath] || ![self canDragRowAtIndexPath:indexPath])
     {
         HPGestureRecognizerCancel(gestureRecognizer);
         return;

--- a/HPReorderTableView/HPReorderTableView.m
+++ b/HPReorderTableView/HPReorderTableView.m
@@ -455,9 +455,7 @@ static void HPGestureRecognizerCancel(UIGestureRecognizer *gestureRecognizer)
     if ([toIndexPath compare:_reorderCurrentIndexPath] == NSOrderedSame) return;
     
     NSInteger originalHeight = _reorderDragView.frame.size.height;
-    // original code uses rectForRowAtIndexPath:, but this bugs out when the delegate implements
-    // estimatedHeightForRowAtIndexPath:
-    NSInteger toHeight = [self.delegate tableView:self heightForRowAtIndexPath:toIndexPath];
+    NSInteger toHeight = [self rectForRowAtIndexPath:toIndexPath].size.height;
     UITableViewCell *toCell = [self cellForRowAtIndexPath:toIndexPath];
     const CGPoint toCellLocation = [gesture locationInView:toCell];
     

--- a/HPReorderTableView/HPReorderTableView.m
+++ b/HPReorderTableView/HPReorderTableView.m
@@ -226,6 +226,9 @@ static void HPGestureRecognizerCancel(UIGestureRecognizer *gestureRecognizer)
         return;
     }
     
+    if ([self.delegate respondsToSelector:@selector(tableView:willBeginReorderingRowAtIndexPath:)]) {
+        [self.delegate tableView:self willBeginReorderingRowAtIndexPath:indexPath];
+    }
     UITableViewCell *cell = [self cellForRowAtIndexPath:indexPath];
     [cell setSelected:NO animated:NO];
     [cell setHighlighted:NO animated:NO];
@@ -247,6 +250,10 @@ static void HPGestureRecognizerCancel(UIGestureRecognizer *gestureRecognizer)
     [self animateShadowOpacityFromValue:0 toValue:_reorderDragView.layer.shadowOpacity];
     [UIView animateWithDuration:HPReorderTableViewAnimationDuration animations:^{
         _reorderDragView.center = CGPointMake(self.center.x, location.y);
+    } completion:^(BOOL finished) {
+        if ([self.delegate respondsToSelector:@selector(tableView:didBeginReorderingRowAtIndexPath:)]) {
+            [self.delegate tableView:self didBeginReorderingRowAtIndexPath:indexPath];
+        }
     }];
     
     [self reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationNone];

--- a/HPReorderTableView/HPReorderTableView.m
+++ b/HPReorderTableView/HPReorderTableView.m
@@ -295,14 +295,16 @@ static void HPGestureRecognizerCancel(UIGestureRecognizer *gestureRecognizer)
 
 - (void)reorderCurrentRowToIndexPath:(NSIndexPath*)toIndexPath
 {
-    [self beginUpdates];
-    [self moveRowAtIndexPath:toIndexPath toIndexPath:_reorderCurrentIndexPath]; // Order is important to keep the empty cell behind
-    if ([self.dataSource respondsToSelector:@selector(tableView:moveRowAtIndexPath:toIndexPath:)])
-    {
-        [self.dataSource tableView:self moveRowAtIndexPath:_reorderCurrentIndexPath toIndexPath:toIndexPath];
+    if ([self canMoveRowAtIndexPath:toIndexPath]) {
+        [self beginUpdates];
+        [self moveRowAtIndexPath:toIndexPath toIndexPath:_reorderCurrentIndexPath]; // Order is important to keep the empty cell behind
+        if ([self.dataSource respondsToSelector:@selector(tableView:moveRowAtIndexPath:toIndexPath:)])
+        {
+            [self.dataSource tableView:self moveRowAtIndexPath:_reorderCurrentIndexPath toIndexPath:toIndexPath];
+        }
+        _reorderCurrentIndexPath = toIndexPath;
+        [self endUpdates];
     }
-    _reorderCurrentIndexPath = toIndexPath;
-    [self endUpdates];
 }
 
 #pragma mark Subclassing

--- a/HPReorderTableView/HPReorderTableView.m
+++ b/HPReorderTableView/HPReorderTableView.m
@@ -90,6 +90,26 @@ static NSString *HPReorderTableViewCellReuseIdentifier = @"HPReorderTableViewCel
     [self registerClass:cellClass forCellReuseIdentifier:HPReorderTableViewCellReuseIdentifier];
 }
 
+- (void)endAnyExistingReorder
+{
+    if (_reorderCurrentIndexPath) {
+        // we repeat a bunch of code here that's in didEndLongPressGestureRecognizer, but we also make sure that
+        // but we don't call reloadRowsAtIndexPaths: on the tableview, since that might cause an out-of-bounds crash
+        if ([self.delegate respondsToSelector:@selector(tableView:didCancelReorderingRowAtIndexPath:)]) {
+            [self.delegate tableView:self didCancelReorderingRowAtIndexPath:_reorderCurrentIndexPath];
+        }
+        [self animateShadowOpacityFromValue:_reorderDragView.layer.shadowOpacity toValue:0];
+        { // Reset
+            [_scrollDisplayLink invalidate];
+            _scrollDisplayLink = nil;
+            _scrollRate = 0;
+            _reorderCurrentIndexPath = nil;
+            _reorderInitialIndexPath = nil;
+        }
+        [self removeReorderDragView];
+    }
+}
+
 #pragma mark - Actions
 
 - (void)recognizeLongPressGestureRecognizer:(UILongPressGestureRecognizer*)gestureRecognizer

--- a/HPReorderTableView/HPReorderTableView.m
+++ b/HPReorderTableView/HPReorderTableView.m
@@ -448,7 +448,9 @@ static void HPGestureRecognizerCancel(UIGestureRecognizer *gestureRecognizer)
     if ([toIndexPath compare:_reorderCurrentIndexPath] == NSOrderedSame) return;
     
     NSInteger originalHeight = _reorderDragView.frame.size.height;
-    NSInteger toHeight = [self rectForRowAtIndexPath:toIndexPath].size.height;
+    // original code uses rectForRowAtIndexPath:, but this bugs out when the delegate implements
+    // estimatedHeightForRowAtIndexPath:
+    NSInteger toHeight = [self.delegate tableView:self heightForRowAtIndexPath:toIndexPath];
     UITableViewCell *toCell = [self cellForRowAtIndexPath:toIndexPath];
     const CGPoint toCellLocation = [gesture locationInView:toCell];
     


### PR DESCRIPTION
I'm not sure if this is desired behavior for other users, but I didn't want to be able to drag rows that weren't allowed to move.  Feel free to merge if it's useful.

If this is done, updating the podspec would be great!
